### PR TITLE
Preserve indentation for serialized object fields after description

### DIFF
--- a/src/Serializers/TypeSerializers/ObjectSerializer.php
+++ b/src/Serializers/TypeSerializers/ObjectSerializer.php
@@ -61,7 +61,7 @@ class ObjectSerializer
         /** @var Field $field */
         foreach ($type->getFields()->getIterator() as $field) {
             $string .= '  ';
-            $string .= (new FieldSerializer())->serialize($field);
+            $string .= str_replace("\n", "\n  ", (new FieldSerializer())->serialize($field));
             $string .= "\n";
         }
 


### PR DESCRIPTION
Previous serialization (no indentation following newline after description):

```
type Query {
  "Accountancy/AccountInvolvedAccount"
accountinvolvedaccount(id: ID): AccountInvolvedAccount
  "Accountancy/AccountInvolvedAccount"
accountinvolvedaccounts: [AccountInvolvedAccount]
}
```

New serialization (preserve indentation):
```
type Query {
  "Accountancy/AccountInvolvedAccount"
  accountinvolvedaccount(id: ID): AccountInvolvedAccount
  "Accountancy/AccountInvolvedAccount"
  accountinvolvedaccounts: [AccountInvolvedAccount]
}
```