### PR TITLE
Preserve indentation for serialized input and interface fields after description

### DIFF
--- a/src/Serializers/TypeSerializers/InputSerializer.php
+++ b/src/Serializers/TypeSerializers/InputSerializer.php
@@ -42,7 +42,7 @@ class InputSerializer
         /** @var Field $field */
         foreach ($type->getFields()->getIterator() as $field) {
             $string .= '  ';
-            $string .= (new FieldSerializer())->serialize($field);
+            $string .= str_replace("\n", "\n  ", (new FieldSerializer())->serialize($field));
             $string .= "\n";
         }
 

--- a/src/Serializers/TypeSerializers/InterfaceSerializer.php
+++ b/src/Serializers/TypeSerializers/InterfaceSerializer.php
@@ -40,7 +40,7 @@ class InterfaceSerializer
         /** @var Field $field */
         foreach ($type->getFields()->getIterator() as $field) {
             $string .= '  ';
-            $string .= (new FieldSerializer())->serialize($field);
+            $string .= str_replace("\n", "\n  ", (new FieldSerializer())->serialize($field));
             $string .= "\n";
         }
 


### PR DESCRIPTION
As discussed in #29 — the same applies to input and interface fields.